### PR TITLE
Add missing bokeh dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,5 @@ pytplot
 numpy
 scipy
 matplotlib
+bokeh
 


### PR DESCRIPTION
## Summary
- update requirements to include bokeh

## Testing
- `python mva_1.py` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_684c3bd7038483269171f9bcf622153e